### PR TITLE
set any type explicitly on constructN

### DIFF
--- a/global/ramda.d.ts
+++ b/global/ramda.d.ts
@@ -349,7 +349,7 @@ declare namespace R {
          * Wraps a constructor function inside a curried function that can be called with the same arguments and returns the same type.
          * The arity of the function returned is specified to allow using variadic constructor functions.
          */
-        constructN(n: number, fn: Function): (...any) => Object;
+        constructN(n: number, fn: Function): (...any: any[]) => Object;
         constructN(n: number, fn: Function): Function;
 
 


### PR DESCRIPTION
After turning on `noImplicitAny` in the `tsconfig.json` of my project, this was the only error from installed typings. I think we should set all types explicitly in the definition file to allow users to turn `noImplicitAny` on.
